### PR TITLE
Add new tooltip explaining "sRGB Color Space" and Stop attempting to add sRGB flag to VTFs.

### DIFF
--- a/VTFCmd/vtfcmd.c
+++ b/VTFCmd/vtfcmd.c
@@ -267,7 +267,7 @@ int main(int argc, char* argv[])
 			else if(stricmp(argv[i], "-srgb") == 0)
 			{
 				CreateOptions.bSRGB = vlTrue;
-				CreateOptions.uiFlags |= TEXTUREFLAGS_SRGB;
+				//CreateOptions.uiFlags |= TEXTUREFLAGS_SRGB;	// This should not be on until VTF version handling is overhauled, Check `VTFFileUtility.h` for a longer comment.
 			}
 			else if(stricmp(argv[i], "-alphaformat") == 0)
 			{

--- a/VTFEdit/VTFFileUtility.h
+++ b/VTFEdit/VTFFileUtility.h
@@ -69,8 +69,14 @@ namespace VTFEdit
 			vlSetFloat(VTFLIB_LUMINANCE_WEIGHT_G, Options->LuminanceWeightG);
 			vlSetFloat(VTFLIB_LUMINANCE_WEIGHT_B, Options->LuminanceWeightB);
 
-			if (Options->sRGB)
-				VTFCreateOptions.uiFlags |= TEXTUREFLAGS_SRGB;
+/*
+*	The bit of code below is commented out because it is invalid and the wrong thing to do on multiple fronts,
+*	Some of why this is wrong/invalid stem from issues with VTFEdit/VTFLib's internal design and or problematic decisions from Valve with later branches/versions of Source depending on how you look at it,
+*	Either way this should never be turned back on unless VTFEdit/VTFLib's handling of different VTF versions gets a major overhaul but even then I doubt this marker flag is that useful or even valid for what it's being used for here.
+*/
+
+//			if (Options->sRGB)
+//				VTFCreateOptions.uiFlags |= TEXTUREFLAGS_SRGB;
 
 			return VTFCreateOptions;
 		}

--- a/VTFEdit/VTFOptions.h
+++ b/VTFEdit/VTFOptions.h
@@ -452,8 +452,8 @@ private: System::Windows::Forms::CheckBox^ chkSrgb;
 			this->chkSrgb->Text = L"sRGB Color Space";
 			this->chkSrgb->UseVisualStyleBackColor = true;
 			this->tipMain->SetToolTip(this->chkSrgb, L"Whether or not to treat input image as sRGB instead of Linear when generating mipma"
-				L"ps or resizing. Turn this off when creating textures that are not meant to be viewed directly, such as normal maps and s"
-				L"pecular masks (aka turn this off for pretty much anything that's not a diffuse/basetexture).");
+				L"ps or resizing.\r\nTurn this off when creating textures that are not meant to be viewed directly, such as normal maps and s"
+				L"pecular masks\r\n(aka turn this off for pretty much anything that's not a diffuse/basetexture).");
 			// 
 			// cboAlphaFormat
 			// 

--- a/VTFEdit/VTFOptions.h
+++ b/VTFEdit/VTFOptions.h
@@ -451,6 +451,9 @@ private: System::Windows::Forms::CheckBox^ chkSrgb;
 			this->chkSrgb->TabIndex = 6;
 			this->chkSrgb->Text = L"sRGB Color Space";
 			this->chkSrgb->UseVisualStyleBackColor = true;
+			this->tipMain->SetToolTip(this->chkSrgb, L"Whether or not to treat input image as sRGB instead of Linear when generating mipma"
+				L"ps or resizing. Turn this off when creating textures that are not meant to be viewed directly, such as normal maps and s"
+				L"pecular masks (aka turn this off for pretty much anything that's not a diffuse/basetexture).");
 			// 
 			// cboAlphaFormat
 			// 


### PR DESCRIPTION
This pull request adds a tooltip for VTFEdit's new "sRGB Color Space" checkbox option attempting to explain what it actually does and it's use cases along with also stopping VTFEdit Reloaded from automatically trying to add the "sRGB" flag to VTFs created with this option since VTFEdit and VTFEdit Reloaded don't properly understand the concept or differences of VTF versions including the fact that in later versions of Source the "sRGB" flag is in an entirely different spot then where VTFEdit thinks it is along with the flag itself being unnecessary since it's meant for internal engine use as well.